### PR TITLE
feat: propagate X-ESI-Error-Limit-Reset through EsiResponse and EsiClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "kevinrob/guzzle-cache-middleware": "^4.0",
         "monolog/monolog": "^3.7",
         "nesbot/carbon": "^3.0",
-        "seatplus/esi-schema": "^1.1"
+        "seatplus/esi-schema": "^1.3"
     },
     "require-dev": {
         "ext-openssl": "*",

--- a/src/DataTransferObjects/EsiResponse.php
+++ b/src/DataTransferObjects/EsiResponse.php
@@ -18,6 +18,8 @@ class EsiResponse
 
     public ?int $error_limit_remain;
 
+    public ?int $error_limit_reset;
+
     public ?int $pages;
 
     // Rate-limit headers (floating-window system, live as of 2025)
@@ -53,6 +55,7 @@ class EsiResponse
         $parsed_headers = $this->parseHeaders($raw_headers);
         $this->parsed_headers = $parsed_headers;
         $this->error_limit_remain = $this->getIntHeader($parsed_headers, 'X-Esi-Error-Limit-Remain');
+        $this->error_limit_reset = $this->getIntHeader($parsed_headers, 'X-Esi-Error-Limit-Reset');
         $this->pages = $this->getIntHeader($parsed_headers, 'X-Pages');
         $this->ratelimitGroup = $this->getHeader($parsed_headers, 'X-Ratelimit-Group');
         $this->ratelimitLimit = $this->parseRatelimitLimit($parsed_headers);

--- a/src/EsiClient.php
+++ b/src/EsiClient.php
@@ -295,6 +295,8 @@ class EsiClient implements EsiTransportInterface
             rateLimitRemaining: $response->ratelimitRemaining,
             rateLimitUsed: $response->ratelimitUsed,
             retryAfter: $response->retryAfter,
+            errorLimitRemaining: $response->error_limit_remain,
+            errorLimitReset: $response->error_limit_reset,
         );
     }
 

--- a/src/Fetcher/GuzzleFetcher.php
+++ b/src/Fetcher/GuzzleFetcher.php
@@ -107,7 +107,9 @@ class GuzzleFetcher
             }
 
             if ($statusCode === 420) {
-                throw new EsiErrorLimitedException;
+                $retryAfter = (int) ($e->getResponse()->getHeader('X-Esi-Error-Limit-Reset')[0] ?? 60);
+
+                throw new EsiErrorLimitedException($retryAfter);
             }
 
             throw new RequestFailedException(


### PR DESCRIPTION
## Summary

Propagates the ESI error-limit headers through the client layer so that eveapi's `RecordingEsiClient` can track the global error budget alongside per-bucket rate-limit state.

## Changes

### `EsiResponse`
- Add `error_limit_reset: ?int` property, parsed from `X-ESI-Error-Limit-Reset` header

### `EsiClient::invoke()`
- Map `error_limit_remain` / `error_limit_reset` into the `EsiRawResponse` DTO (fields added in esi-schema 1.3)

### `GuzzleFetcher`
- Pass `retryAfter` to `EsiErrorLimitedException` using the `X-Esi-Error-Limit-Reset` header value so callers know exactly how long to wait

### `composer.json`
- Bump `seatplus/esi-schema` to `^1.3`

## Context

ESI error limit headers:
- `X-ESI-Error-Limit-Remain` — errors left in this time frame
- `X-ESI-Error-Limit-Reset` — seconds left until next time frame and errors reset to zero

These are mutually exclusive with the bucket rate-limit headers (`X-Ratelimit-*`).