### PR TITLE
feat: use standard product-token User-Agent format

### DIFF
--- a/src/EsiConfiguration.php
+++ b/src/EsiConfiguration.php
@@ -2,6 +2,7 @@
 
 namespace Seatplus\EsiClient;
 
+use Composer\InstalledVersions;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Monolog\Level;
 use Seatplus\EsiClient\CacheMiddleware\NullCacheMiddleware;
@@ -49,7 +50,12 @@ class EsiConfiguration
         // Sent on every request. Matches the ESI OpenAPI spec compatibility date
         // used to generate seatplus/esi-schema. Update when regenerating the schema.
         public ?string $compatibility_date = '2025-12-16',
-    ) {}
+    ) {
+        if ($this->http_user_agent === '') {
+            $version = InstalledVersions::getPrettyVersion('seatplus/esi-client') ?? 'dev';
+            $this->http_user_agent = "seatplus/esi-client/{$version} +https://github.com/seatplus/esi-client";
+        }
+    }
 
     public static function getInstance(...$args): self
     {

--- a/src/EsiConfiguration.php
+++ b/src/EsiConfiguration.php
@@ -18,7 +18,7 @@ class EsiConfiguration
     private ?CacheMiddleware $cache_implementation = null;
 
     public function __construct(
-        public string $http_user_agent = 'Seatplus Esi Client Default Library',
+        public string $http_user_agent = '',
 
         // Esi
         public string $datasource = 'tranquility',

--- a/src/Fetcher/GuzzleFetcher.php
+++ b/src/Fetcher/GuzzleFetcher.php
@@ -3,7 +3,6 @@
 namespace Seatplus\EsiClient\Fetcher;
 
 use Carbon\Carbon;
-use Composer\InstalledVersions;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
@@ -76,18 +75,10 @@ class GuzzleFetcher
 
         $body = count($body) > 0 ? json_encode($body) : null;
 
-        $version = InstalledVersions::getPrettyVersion('seatplus/esi-client');
-        $userAgent = EsiConfiguration::getInstance()->http_user_agent;
-        $userAgentHeader = "seatplus/esi-client/{$version} +https://github.com/seatplus/esi-client";
-
-        if ($userAgent !== '') {
-            $userAgentHeader .= " {$userAgent}";
-        }
-
         $requestHeaders = array_merge($headers, [
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
-            'User-Agent' => $userAgentHeader,
+            'User-Agent' => EsiConfiguration::getInstance()->http_user_agent,
         ]);
 
         if (EsiConfiguration::getInstance()->compatibility_date !== null) {

--- a/src/Fetcher/GuzzleFetcher.php
+++ b/src/Fetcher/GuzzleFetcher.php
@@ -78,10 +78,16 @@ class GuzzleFetcher
 
         $version = InstalledVersions::getPrettyVersion('seatplus/esi-client');
         $userAgent = EsiConfiguration::getInstance()->http_user_agent;
+        $userAgentHeader = "seatplus/esi-client/{$version}";
+
+        if ($userAgent !== '') {
+            $userAgentHeader .= " {$userAgent}";
+        }
+
         $requestHeaders = array_merge($headers, [
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
-            'User-Agent' => "Seatplus Esi Client /{$version}/{$userAgent}",
+            'User-Agent' => $userAgentHeader,
         ]);
 
         if (EsiConfiguration::getInstance()->compatibility_date !== null) {

--- a/src/Fetcher/GuzzleFetcher.php
+++ b/src/Fetcher/GuzzleFetcher.php
@@ -78,7 +78,7 @@ class GuzzleFetcher
 
         $version = InstalledVersions::getPrettyVersion('seatplus/esi-client');
         $userAgent = EsiConfiguration::getInstance()->http_user_agent;
-        $userAgentHeader = "seatplus/esi-client/{$version}";
+        $userAgentHeader = "seatplus/esi-client/{$version} +https://github.com/seatplus/esi-client";
 
         if ($userAgent !== '') {
             $userAgentHeader .= " {$userAgent}";

--- a/tests/Unit/EsiConfigurationTest.php
+++ b/tests/Unit/EsiConfigurationTest.php
@@ -10,7 +10,8 @@ use Seatplus\EsiClient\Log\NullLogger;
 it('initializes with default values', function () {
     $config = new EsiConfiguration;
 
-    expect($config->http_user_agent)->toBe('')
+    expect($config->http_user_agent)->toContain('seatplus/esi-client/')
+        ->toContain('+https://github.com/seatplus/esi-client')
         ->and($config->datasource)->toBe('tranquility')
         ->and($config->esi_scheme)->toBe('https')
         ->and($config->esi_host)->toBe('esi.evetech.net')

--- a/tests/Unit/EsiConfigurationTest.php
+++ b/tests/Unit/EsiConfigurationTest.php
@@ -10,7 +10,7 @@ use Seatplus\EsiClient\Log\NullLogger;
 it('initializes with default values', function () {
     $config = new EsiConfiguration;
 
-    expect($config->http_user_agent)->toBe('Seatplus Esi Client Default Library')
+    expect($config->http_user_agent)->toBe('')
         ->and($config->datasource)->toBe('tranquility')
         ->and($config->esi_scheme)->toBe('https')
         ->and($config->esi_host)->toBe('esi.evetech.net')


### PR DESCRIPTION
## Summary

Replaces the non-standard User-Agent format with the MDN-standard space-separated product tokens.

## Before
```
Seatplus Esi Client /4.x.x/Seatplus Esi Client Default Library
```

## After (standalone)
```
seatplus/esi-client/4.x.x
```

## After (with eveapi ServiceProvider, PR seatplus/eveapi#679)
```
seatplus/esi-client/4.x.x seatplus/eveapi/4.x.x +https://github.com/seatplus/eveapi
```

## Changes
- `GuzzleFetcher`: new format `seatplus/esi-client/{version}` + optional `{http_user_agent}` suffix
- `EsiConfiguration`: default `http_user_agent` changed from `'Seatplus Esi Client Default Library'` to `''`