### PR TITLE
chore: strict types, return types, remove DataTransferObject, modernise esi-client

### DIFF
--- a/src/CacheMiddleware/CacheMiddlewareInterface.php
+++ b/src/CacheMiddleware/CacheMiddlewareInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\CacheMiddleware;
 
 use Kevinrob\GuzzleCache\CacheMiddleware;

--- a/src/CacheMiddleware/LaravelFileCacheMiddleware.php
+++ b/src/CacheMiddleware/LaravelFileCacheMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\CacheMiddleware;
 
 use Illuminate\Support\Facades\Cache;

--- a/src/CacheMiddleware/NullCacheMiddleware.php
+++ b/src/CacheMiddleware/NullCacheMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\CacheMiddleware;
 
 use Kevinrob\GuzzleCache\CacheMiddleware;

--- a/src/DataTransferObjects/EsiAuthentication.php
+++ b/src/DataTransferObjects/EsiAuthentication.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\DataTransferObjects;
 
 use Firebase\JWT\JWT;

--- a/src/DataTransferObjects/EsiResponse.php
+++ b/src/DataTransferObjects/EsiResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\DataTransferObjects;
 
 /**

--- a/src/EsiClient.php
+++ b/src/EsiClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient;
 
 use GuzzleHttp\Psr7\Uri;
@@ -274,7 +276,7 @@ class EsiClient implements EsiTransportInterface
         array $requestBody = [],
     ): EsiRawResponse {
         $uri = $this->buildDataUri($path, $pathValues, $queryParams);
-        $response = $this->fetcher->call($method, $uri, $requestBody);
+        $response = $this->fetcher->call($method, (string) $uri, $requestBody);
 
         // Extract cursor tokens if the response body contains a `cursor` object.
         // Cursor routes (x-pagination: cursor) embed {before, after} in the body.
@@ -325,7 +327,7 @@ class EsiClient implements EsiTransportInterface
         return $this->getConfiguration()->getLogger();
     }
 
-    private function getConfiguration(?string $property = null): EsiConfiguration|string
+    private function getConfiguration(?string $property = null): EsiConfiguration|string|int|null
     {
         return $property ? EsiConfiguration::getInstance()->$property : EsiConfiguration::getInstance();
     }
@@ -363,7 +365,7 @@ class EsiClient implements EsiTransportInterface
                 if (! array_key_exists($match, $data)) {
                     throw new UriDataMissingException("Data for {$match} is missing. Please provide this by setting a value for {$match}.");
                 }
-                $uri = str_replace("{{$match}}", $data[$match], $uri);
+                $uri = str_replace("{{$match}}", (string) $data[$match], $uri);
             }
         }
 

--- a/src/EsiConfiguration.php
+++ b/src/EsiConfiguration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient;
 
 use Composer\InstalledVersions;

--- a/src/Exceptions/EsiErrorLimitedException.php
+++ b/src/Exceptions/EsiErrorLimitedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Exceptions;
 
 class EsiErrorLimitedException extends \RuntimeException

--- a/src/Exceptions/EsiRateLimitedException.php
+++ b/src/Exceptions/EsiRateLimitedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Exceptions;
 
 class EsiRateLimitedException extends \RuntimeException

--- a/src/Exceptions/ExpiredRefreshTokenException.php
+++ b/src/Exceptions/ExpiredRefreshTokenException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Exceptions;
 
 use Seatplus\EsiClient\Services\UpdateRefreshTokenService;
@@ -8,7 +10,10 @@ class ExpiredRefreshTokenException extends \Exception
 {
     public function __construct()
     {
-        parent::__construct('The given refresh_token is already or will be expiring within the next minute. '
-            .'Please refresh the token and try again. EsiClient offers a service: '.UpdateRefreshTokenService::class.' to do so.', 422);
+        parent::__construct(
+            'The given refresh_token is already or will be expiring within the next minute. '
+            .'Please refresh the token and try again. EsiClient offers a service: '.UpdateRefreshTokenService::class.' to do so.',
+            422
+        );
     }
 }

--- a/src/Exceptions/InvalidAuthenticationException.php
+++ b/src/Exceptions/InvalidAuthenticationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Exceptions;
 
 class InvalidAuthenticationException extends \Exception {}

--- a/src/Exceptions/RequestFailedException.php
+++ b/src/Exceptions/RequestFailedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Exceptions;
 
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;

--- a/src/Exceptions/UriDataMissingException.php
+++ b/src/Exceptions/UriDataMissingException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Exceptions;
 
 class UriDataMissingException extends \Exception {}

--- a/src/Fetcher/GuzzleFetcher.php
+++ b/src/Fetcher/GuzzleFetcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Fetcher;
 
 use Carbon\Carbon;

--- a/src/Log/LogInterface.php
+++ b/src/Log/LogInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Log;
 
 interface LogInterface

--- a/src/Log/NullLogger.php
+++ b/src/Log/NullLogger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Log;
 
 class NullLogger implements LogInterface

--- a/src/Log/RotatingFileLogger.php
+++ b/src/Log/RotatingFileLogger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of SeAT
  *

--- a/src/Services/JwtService.php
+++ b/src/Services/JwtService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Services;
 
 use Firebase\JWT\JWK;

--- a/src/Services/UpdateRefreshTokenService.php
+++ b/src/Services/UpdateRefreshTokenService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Services;
 
 use GuzzleHttp\Client;

--- a/src/Services/VerifyAccessToken.php
+++ b/src/Services/VerifyAccessToken.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\EsiClient\Services;
 
 use Firebase\JWT\ExpiredException;


### PR DESCRIPTION
## Summary

Bottom-up code quality overhaul for esi-client.

### Changes

- **strict_types=1** on all 19 source files
- **Remove `spatie/data-transfer-object`** — `EsiAuthentication` and `EsiConfiguration` rewritten as plain PHP 8 classes with typed properties / named constructor params
- **Return types** added to all methods (`void`, `EsiResponse`, `CheckAccess`, etc.)
- **snake_case → camelCase**: `get_data()` → `getData()`
- **String interpolation** over concatenation/sprintf in `GuzzleFetcher`
- **EsiResponse**: fix `response_code` type (`string` → `int`), fix PHP 8.3 `ArrayObject` deprecation (pass array, not object)
- **EsiClient**: cast Guzzle `Uri` to `string` before `GuzzleFetcher::call()`
- **UpdateRefreshTokenService**: update to `firebase/php-jwt` v6 API (remove 3rd arg from `JWT::decode()`); add return + parameter types
- **GuzzleFetcher**: `Carbon::parse()` over `new Carbon()`, camelCase locals
- **Configuration**: add `reset()` static for test isolation between singleton uses
- **composer.json**: PHP `^8.3`, `firebase/php-jwt ^6.0`, Pest `^3.0`; remove `fzaninotto/faker`, `spatie/data-transfer-object`; re-add `mikey179/vfsstream` (needed by logger tests)
- **Tests**: updated for new constructor APIs and JWT v6 (`Key` objects, `kid` header)

### Tests

All 25 tests pass, 1 minor framework-level deprecation notice.