### PR TITLE
fix: withToken() carries the token's real expiry (JWT exp)

### DIFF
--- a/src/DataTransferObjects/EsiAuthentication.php
+++ b/src/DataTransferObjects/EsiAuthentication.php
@@ -16,6 +16,27 @@ class EsiAuthentication
         public string $token_expires = '1970-01-01 00:00:00',
     ) {}
 
+    /**
+     * Derive the access token's real expiry from its JWT `exp` claim.
+     *
+     * An access token supplied via EsiClient::withToken() has no separately-provided
+     * expiry; without this it falls back to the 1970 default and every request is
+     * wrongly rejected as expiring. The JWT itself is the source of truth.
+     */
+    public static function expiresFromToken(string $accessToken): string
+    {
+        $parts = explode('.', $accessToken);
+
+        if (count($parts) < 2) {
+            return '1970-01-01 00:00:00';
+        }
+
+        $payload = json_decode(JWT::urlsafeB64Decode($parts[1]));
+        $exp = data_get($payload, 'exp');
+
+        return $exp ? date('Y-m-d H:i:s', (int) $exp) : '1970-01-01 00:00:00';
+    }
+
     public function getScopes(): array
     {
         $jwt_payload_base64_encoded = explode('.', $this->access_token)[1];

--- a/src/EsiClient.php
+++ b/src/EsiClient.php
@@ -78,6 +78,7 @@ class EsiClient implements EsiTransportInterface
         $clone->authentication = new EsiAuthentication(
             access_token: $accessToken,
             refresh_token: '',
+            token_expires: EsiAuthentication::expiresFromToken($accessToken),
         );
         $clone->fetcher = $clone->createFetcher();
 

--- a/tests/Unit/EsiAuthenticationTest.php
+++ b/tests/Unit/EsiAuthenticationTest.php
@@ -13,3 +13,19 @@ it('is possible to create EsiAuthenticationContainer without esi id and secret',
         ->toBeInstanceOf(EsiAuthentication::class)
         ->token_expires->toBe('now');
 });
+
+it('derives the expiry from the access token JWT exp claim', function () {
+    $exp = strtotime('2030-06-15 12:34:56');
+
+    $token = buildJWT(json_encode(['exp' => $exp]));
+
+    expect(EsiAuthentication::expiresFromToken($token))
+        ->toBe(date('Y-m-d H:i:s', $exp));
+});
+
+it('falls back to epoch when the token is malformed or has no exp', function () {
+    expect(EsiAuthentication::expiresFromToken('not-a-jwt'))
+        ->toBe('1970-01-01 00:00:00')
+        ->and(EsiAuthentication::expiresFromToken(buildJWT(json_encode(['scp' => []]))))
+        ->toBe('1970-01-01 00:00:00');
+});


### PR DESCRIPTION
`EsiClient::withToken($accessToken)` built an `EsiAuthentication` without `token_expires`, leaving the `'1970-01-01'` default. `GuzzleFetcher::getToken()` then always threw `ExpiredRefreshTokenException` (`token_expires <= now+1min`) — so **every authenticated ESI call made via `withToken` failed**, even with a freshly-refreshed token. The exception is swallowed by the queued job's `fail()` path, so wallet/mail/etc. jobs silently persisted nothing.

Fix: derive `token_expires` from the access token's JWT `exp` claim (`EsiAuthentication::expiresFromToken`), the real expiry. Added regression tests.

This unblocks all authenticated ESI jobs (wallet, mail, assets, skills, …).