### PR TITLE
chore: only log ratelimit-remaining/error-limit when the header is present

### DIFF
--- a/src/Fetcher/GuzzleFetcher.php
+++ b/src/Fetcher/GuzzleFetcher.php
@@ -149,7 +149,20 @@ class GuzzleFetcher
             $reason = strtolower($response->getReasonPhrase());
             $errorLimitRemain = implode(' ', $response->getHeader('X-Esi-Error-Limit-Remain'));
             $ratelimitRemaining = implode(' ', $response->getHeader('X-Ratelimit-Remaining'));
-            $message = "[http {$status}, {$reason}] {$method} -> {$uri} [t/e: {$elapsed}s/{$errorLimitRemain} ratelimit-remaining: {$ratelimitRemaining}]";
+
+            // Only include a metric when ESI actually returned its header. X-Ratelimit-Remaining
+            // is sent solely by token-bucket endpoints (e.g. assets) and X-Esi-Error-Limit-Remain
+            // isn't returned by all of them either — so print each only when present instead of
+            // emitting an empty "ratelimit-remaining: " that reads as a bug.
+            $meta = ["t: {$elapsed}s"];
+            if ($errorLimitRemain !== '') {
+                $meta[] = "error-limit: {$errorLimitRemain}";
+            }
+            if ($ratelimitRemaining !== '') {
+                $meta[] = "ratelimit-remaining: {$ratelimitRemaining}";
+            }
+
+            $message = "[http {$status}, {$reason}] {$method} -> {$uri} [".implode(', ', $meta).']';
         }
 
         match ($level) {

--- a/tests/Unit/Fetcher/GuzzleFetcherTest.php
+++ b/tests/Unit/Fetcher/GuzzleFetcherTest.php
@@ -246,3 +246,51 @@ it('logs fetcher activity with cache hit', function (string $log_level) {
     // Invoke the method
     $method->invokeArgs($fetcher, [$log_level, $response, 'GET', '/test/uri', microtime(true)]);
 })->with(['error', 'info', 'debug', 'warning']);
+
+it('logs rate-limit metrics only when ESI returns those headers', function () {
+    $response = mock(ResponseInterface::class, function (MockInterface $mock) {
+        $mock->shouldReceive('getHeader')->with('X-Kevinrob-Cache')->andReturn([]);
+        $mock->shouldReceive('getHeader')->with('X-Esi-Error-Limit-Remain')->andReturn(['95']);
+        $mock->shouldReceive('getHeader')->with('X-Ratelimit-Remaining')->andReturn(['80']);
+        $mock->shouldReceive('getStatusCode')->andReturn(200);
+        $mock->shouldReceive('getReasonPhrase')->andReturn('OK');
+    });
+
+    $logger = mock(LogInterface::class, function (MockInterface $logger) {
+        $logger->shouldReceive('log')
+            ->once()
+            ->with(Mockery::on(fn (string $message): bool => str_contains($message, 'error-limit: 95')
+                && str_contains($message, 'ratelimit-remaining: 80')));
+    });
+
+    $fetcher = new GuzzleFetcher(logger: $logger);
+
+    $reflection = new ReflectionClass($fetcher);
+    $method = $reflection->getMethod('logFetcherActivity');
+
+    $method->invokeArgs($fetcher, ['info', $response, 'GET', '/test/uri', microtime(true)]);
+});
+
+it('omits rate-limit metrics when ESI does not return those headers', function () {
+    $response = mock(ResponseInterface::class, function (MockInterface $mock) {
+        $mock->shouldReceive('getHeader')->with('X-Kevinrob-Cache')->andReturn([]);
+        $mock->shouldReceive('getHeader')->with('X-Esi-Error-Limit-Remain')->andReturn([]);
+        $mock->shouldReceive('getHeader')->with('X-Ratelimit-Remaining')->andReturn([]);
+        $mock->shouldReceive('getStatusCode')->andReturn(200);
+        $mock->shouldReceive('getReasonPhrase')->andReturn('OK');
+    });
+
+    $logger = mock(LogInterface::class, function (MockInterface $logger) {
+        $logger->shouldReceive('log')
+            ->once()
+            ->with(Mockery::on(fn (string $message): bool => ! str_contains($message, 'error-limit:')
+                && ! str_contains($message, 'ratelimit-remaining:')));
+    });
+
+    $fetcher = new GuzzleFetcher(logger: $logger);
+
+    $reflection = new ReflectionClass($fetcher);
+    $method = $reflection->getMethod('logFetcherActivity');
+
+    $method->invokeArgs($fetcher, ['info', $response, 'GET', '/test/uri', microtime(true)]);
+});


### PR DESCRIPTION
The critical `withToken` token-expiry fix originally on this branch is **already merged to `4.x` via #34** (thanks!), so this PR is now reduced to just the log-formatting cleanup that surfaced during debugging.

`GuzzleFetcher::logFetcherActivity()` always interpolated both `ratelimit-remaining` and `error-limit`, so every **non-bucket** endpoint logged a blank `ratelimit-remaining:` tail (ESI only returns `X-Ratelimit-Remaining` on token-bucket endpoints like `/assets/`). Now it emits only the headers ESI actually returned:
- bucket endpoint → `… [t: 0.52s, ratelimit-remaining: 1798]`
- normal endpoint → `… [t: 0.32s, error-limit: 100]`
- neither → `… [t: 0.12s]`

Rebased onto the merged `4.x`, so no conflict. Full esi-client suite green; Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)