### PR TITLE
test: analyse tests/ with PHPStan (pest-plugin-phpstan rollout pilot)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "pestphp/pest-plugin-phpstan": "^5.0",
         "pestphp/pest-plugin-type-coverage": "^5.0",
         "phpstan/phpstan": "^2.1.46",
+        "phpstan/phpstan-mockery": "^2.0",
         "rector/rector": "^2.0"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,15 +1,27 @@
 includes:
     # Pest-aware static analysis (understands it()/expect()/$this).
-    # `tests` is intentionally NOT yet in `paths` below — pointing PHPStan at the
-    # suite surfaces a batch of Mockery false-positives + redundant-expectation
-    # findings that are handled in a dedicated follow-up, not this tooling bump.
     - vendor/pestphp/pest-plugin-phpstan/extension.neon
+    # Understands Mockery's dynamic API (shouldReceive(), etc.).
+    - vendor/phpstan/phpstan-mockery/extension.neon
 
 parameters:
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
     level: 4
     paths:
         - src
+        - tests
     tmpDir: build/phpstan
+    ignoreErrors:
+        # pest.expectation.redundant flags assertions a strict return type already
+        # guarantees (e.g. toBeInstanceOf() on a typed return). With failOnRisky=true
+        # the sole-assertion tests can't just drop them, so silence this style rule —
+        # pest.expectation.impossible (real, unsatisfiable assertions) stays active.
+        -
+            identifier: pest.expectation.redundant
+        # vfsStream's getChild() returns the base vfsStreamContent; getContent() lives
+        # on the vfsStreamFile subclass. A third-party typing gap, not a code issue.
+        -
+            message: '#Call to an undefined method org\\bovigo\\vfs\\vfsStreamContent::getContent\(\)#'
+            path: tests/Unit/Logger/RotatingFileLoggerTest.php
 
 


### PR DESCRIPTION
## What & why
`pest-plugin-phpstan` was wired into the Pest 5 bump (#36) but **`tests` was never in phpstan `paths`**, so the suite wasn't analysed and the plugin was inert. This finishes the rollout — the pilot for eveapi/auth/web (#38).

## Changes
- **`tests` added to `phpstan.neon.dist` `paths`** — PHPStan now actually analyses the test suite.
- **`phpstan/phpstan-mockery`** added (dep + `includes`) — understands Mockery's dynamic API. This alone cleared the bulk of findings (60 → 4 real + 24 style).
- Two principled `ignoreErrors`:
  - `pest.expectation.redundant` (identifier) — silenced. It flags assertions a strict return type already guarantees (e.g. `toBeInstanceOf()` on a typed return); with `failOnRisky=true`, the sole-assertion tests can't just be deleted. **`pest.expectation.impossible` stays active** (that one catches real, unsatisfiable assertions).
  - `vfsStreamContent::getContent()` in one logger test — a third-party typing gap (`getChild()` returns the base interface; `getContent()` is on the `vfsStreamFile` subclass).

## Result
`composer test` green with `tests` analysed: `test:types` ✓ (src + tests), `test:type-coverage` 100% ✓, `test:lint` ✓.

## Rollout note
esi-client is the simplest (plain PHPStan, no Eloquent). For eveapi/auth/web, **Larastan already resolves the model access**, so the same recipe (tests-in-paths + phpstan-mockery + handle `#[Scope]` filterBy + clean genuine findings) applies — see each repo's PHPStan issue.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)