### PR TITLE
feat!: adopt esi-schema 3.0 — PHP ^8.5, ESI 2026-07-21, getCharactersDetail

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -2,11 +2,15 @@ name: Formats
 
 on:
   push:
+    # Branch-filtered deliberately: without this the job ran on every branch and published a
+    # check named `ci` — the same context branch protection requires — so a PR whose base was
+    # not covered by tests.yml showed a single green tick that looked like a validated build.
+    branches: [ 2.x, 3.x, 4.x, 5.x ]
     paths:
       - '**.php'
       - 'composer.json'
   pull_request:
-    branches: [ 3.x, 4.x ]
+    branches: [ 3.x, 4.x, 5.x ]
 
 jobs:
   ci:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ 2.x, 3.x, 4.x ]
+    branches: [ 2.x, 3.x, 4.x, 5.x ]
   pull_request:
-    branches: [ 2.x, 3.x, 4.x ]
+    branches: [ 2.x, 3.x, 4.x, 5.x ]
 
 jobs:
   ci:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,74 @@
 # Changelog
 
 All notable changes to `esi-client` will be documented in this file.
+Releases before 5.0.0 are documented in the [GitHub releases](https://github.com/seatplus/esi-client/releases).
+
+## 5.0.0 - unreleased
+
+`5.x` is the PHP 8.5 / ESI `2026-07-21` line. `4.x` remains on PHP 8.3+ and ESI `2025-12-16` and
+receives bug fixes only.
+
+### Breaking
+
+- **PHP 8.5 is now the minimum** (`php: ^8.5`, was `^8.3`). PHP 8.3 and 8.4 consumers must stay on
+  `4.1.x`; `composer update` will hold them there silently rather than reporting a conflict.
+- **`seatplus/esi-schema` is now `^3.0`** (was `^1.3`). esi-schema 3.0 requires PHP 8.5 and is a
+  breaking DTO release; no version of this package accepts both `1.x` and `3.x`.
+- **The compatibility date sent on every request moved `2025-12-16` → `2026-07-21`.**
+  `X-Compatibility-Date` is no longer a literal in this package — it is read from
+  `Seatplus\EsiSchema\GeneratedSpec::COMPATIBILITY_DATE`, so the generated DTOs and the wire contract
+  can no longer drift apart. In ESI's own terms the effective bucket moves `2020-01-01` →
+  `2026-06-09`, so response shapes may have changed for endpoints this package does not itself assert
+  against. Re-verify anything that reads ESI fields directly.
+- **`CharacterResource::getCharactersCharacterId()` is now `getCharactersDetail()`** — CCP renamed the
+  operation at compatibility date `2026-06-09`. The signature is unchanged:
+  `getCharactersDetail(int $characterId): CharactersDetail`.
+- **`CharactersDetail::$title` was removed.** esi-schema 3.0 replaces it with `?string $corporation_title`
+  and `?string $character_title_id`, and adds a required `int $achievement_score`. Consumers persisting
+  `title` must choose a replacement explicitly — this is a semantic decision, not a rename.
+- **The Sovereignty map and structures operations were removed upstream**
+  (`Resources\Sovereignty\GetSovereigntyMap`, `GetSovereigntyStructures`, and the
+  `Responses\SovereigntyMapGetItem` / `SovereigntyStructuresGetItem` DTOs). `EsiClient::sovereignty()`
+  still exists; those two routes do not.
+- **The HTTP cache key is now scoped to the caller and the compatibility date.**
+  `LaravelFileCacheMiddleware` now builds `EsiPrivateCacheStrategy`, keying on
+  `sha256(compatibility-date | token subject | method + URI)` instead of method + URI alone. Entries
+  cached by `4.x` are unreachable from 5.0.0, so expect one cold-fetch cycle per endpoint after
+  upgrading and budget for it against ESI's 1800-request / 15-minute window. Old entries are not
+  deleted; `php artisan cache:clear` reclaims the space.
+
+### Fixed
+
+- **Authenticated responses could be served to the wrong character.** ESI does not send
+  `Vary: Authorization`, and the cache key did not include the token, so two characters requesting the
+  same authenticated URI shared one entry — a character lacking a corporation role could be served a
+  payload another character fetched, with ESI never seeing the request it would have refused. Because
+  ESI sends `ETag`, those entries were stored with an infinite TTL and did not age out. The key now
+  includes the access token's JWT `sub`, which is stable across token refresh. Only deployments that
+  opted into a response cache were affected; the shipped default is `NullCacheMiddleware`, which
+  caches nothing.
+
+### Action required
+
+- **If you implement `CacheMiddlewareInterface` yourself**, your code still compiles and runs, but it
+  keeps the unscoped cache key and the cross-character bleed described above. Build your
+  `CacheMiddleware` on `Seatplus\EsiClient\CacheMiddleware\Strategy\EsiPrivateCacheStrategy` instead of
+  `Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy`. Consumers using the shipped
+  `LaravelFileCacheMiddleware` need no change.
+
+### Changed
+
+- `guzzlehttp/guzzle` is now declared explicitly in `require`. It was already used directly by
+  `GuzzleFetcher` while arriving only transitively through the cache middleware.
+- `illuminate/cache` (dev) widened to `^11.23 || ^12.0 || ^13.0` to cover the Laravel line consumers
+  actually run.
+
+### Unchanged
+
+`EsiClient::invoke()`, `EsiTransportInterface`, `EsiRawResponse`, `EsiCursor`, `EsiResult`,
+`AbstractEsiDto`, all 36 resource wrappers, `EsiConfiguration`'s public API (the `compatibility_date`
+constructor argument still accepts an override), authentication, logging, and rate-limit/error-limit
+handling.
 
 ## 1.0.0 - 202X-XX-XX
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,25 @@
 
 A standalone ESI (Eve Swagger Interface) Client Library using kevinrob/guzzle-cache-middleware.
 
-> **ESI compatibility date:** This branch of `esi-client` targets ESI compatibility date **`2025-12-16`** and forward.
-> Responses DTOs are sourced from [`seatplus/esi-schema`](https://github.com/seatplus/esi-schema) (`1.x`).
+> **Requires PHP 8.5.**
+>
+> **ESI compatibility date:** this branch targets ESI compatibility date **`2026-07-21`**.
+> The value is not configured here — it is read from
+> [`seatplus/esi-schema`](https://github.com/seatplus/esi-schema)'s `GeneratedSpec::COMPATIBILITY_DATE`
+> and sent as `X-Compatibility-Date` on every request, so the generated response DTOs and the shape the
+> server returns cannot disagree. Override it with `new EsiConfiguration(compatibility_date: '…')`, or
+> pass `null` to omit the header and let ESI apply its own default. ESI validates the header and
+> answers `400` for a malformed or out-of-range date, so a typo fails every request.
 > If CCP publishes a new breaking compatibility date, a new major version of both packages will be released.
+
+| esi-client | PHP (declared) | PHP (tested) | esi-schema | ESI compatibility date | status |
+|---|---|---|---|---|---|
+| `5.x` | `^8.5` | 8.5 | `^3.0` | `2026-07-21` (ESI bucket `2026-06-09`) | active |
+| `4.x` | `^8.3` | 8.5 only | `^1.3` | `2025-12-16` (bucket `2020-01-01`) | bug fixes only |
+
+`4.x` declares `php: ^8.3`, but its `require-dev` pins `pestphp/pest ^5.0`, which needs `php ^8.4` —
+`composer install` of `4.x` fails on 8.3 and CI never tests below 8.5. Consumers are unaffected, since
+dev dependencies are not installed for them, but that 8.3 floor is unverified.
 
 ## Installation
 
@@ -41,7 +57,7 @@ echo $alliance->ticker;
 $alliance->isCachedLoad;       // bool — true if served from RFC 7234 cache
 
 // Authenticated endpoint — returns CharactersDetail directly
-$character = $sdk->withToken($accessToken)->characters()->getCharactersCharacterId(95725047);
+$character = $sdk->withToken($accessToken)->characters()->getCharactersDetail(95725047);
 echo $character->name;
 
 // Paginated list — returns EsiResult (pages metadata needed)
@@ -67,7 +83,32 @@ $response = $esi->invoke('get', '/characters/{character_id}/', [
 // $response->isCachedLoad() — true if served from RFC 7234 cache
 ```
 
-### Rate limiting
+## Caching
+
+**There is no response cache by default.** `EsiConfiguration::$cache_middleware` defaults to
+`NullCacheMiddleware`, which stores nothing; you opt in by setting it to `LaravelFileCacheMiddleware`
+(or your own `CacheMiddlewareInterface` implementation).
+
+When you do opt in, responses are cached per RFC 7234 and the key is scoped to both the caller and the
+compatibility date — `sha256(compatibility-date | token subject | method + URI)`, via
+`Seatplus\EsiClient\CacheMiddleware\Strategy\EsiPrivateCacheStrategy`. The token scoping matters: ESI
+does not send `Vary: Authorization`, so an unscoped key lets two characters requesting the same
+authenticated URI share one entry, and a character lacking a corporation role can be served a payload
+another character fetched without ESI ever seeing the request it would have refused. The subject comes
+from the access token's JWT `sub` claim, which is stable across token refresh; a token that is not a
+readable JWT falls back to hashing the header, which isolates it but only caches for that token's
+lifetime. Note the claim is read without signature verification — that only helps against a caller who
+cannot already supply an arbitrary token.
+
+A compatibility-date change means a one-time cold cache for the affected entries. Old entries are not
+deleted; on the `file` store, responses carrying an `ETag` were saved with an infinite TTL, so run
+`php artisan cache:clear` if you want the space back.
+
+**If you implement `CacheMiddlewareInterface` yourself**, build on `EsiPrivateCacheStrategy` rather than
+`Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy` — otherwise your cache keeps the unscoped key and
+the cross-character bleed above.
+
+## Rate limiting
 
 ESI enforces a **1800-token / 15-minute** rolling window (one token consumed per request,
 irrespective of response code). `esi-client` itself does not throttle — rate limiting is
@@ -96,7 +137,9 @@ As of today this esi client only supports Laravel Cache Middleware. However [`Ke
 * PSR6 
 * WordPress Object Cache
 
-if you plan to use this client with any of these a proper CacheMiddleware would be needed.
+if you plan to use this client with any of these a proper CacheMiddleware would be needed. Build its
+strategy on `Seatplus\EsiClient\CacheMiddleware\Strategy\EsiPrivateCacheStrategy` so the cache key stays
+scoped to the caller and the compatibility date — see [Caching](#caching).
 Same goes to the HTTP client. This client and its cache middleware had been designed to use with Guzzle7 (but you can use it with any PSR-7 HTTP client). Please submit your PR accordingly implementing other HTTP clients.
 
 Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.

--- a/composer.json
+++ b/composer.json
@@ -23,18 +23,19 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-json": "*",
         "firebase/php-jwt": "^7.0",
+        "guzzlehttp/guzzle": "^7.9.2",
         "kevinrob/guzzle-cache-middleware": "^7.0",
         "monolog/monolog": "^3.7",
         "nesbot/carbon": "^3.0",
-        "seatplus/esi-schema": "^1.3"
+        "seatplus/esi-schema": "^3.0"
     },
     "require-dev": {
         "ext-openssl": "*",
         "fakerphp/faker": "^1.23",
-        "illuminate/cache": "^11.23",
+        "illuminate/cache": "^11.23 || ^12.0 || ^13.0",
         "laravel/pint": "^1.17",
         "mikey179/vfsstream": "^1",
         "mockery/mockery": "^1.4",

--- a/rector.php
+++ b/rector.php
@@ -12,7 +12,6 @@ return RectorConfig::configure()
     ->withPaths([
         __DIR__.'/src',
         __DIR__.'/tests',
-        __DIR__.'/bin',
     ]);
 // uncomment to reach your current PHP version
 // ->withPhpSets()

--- a/src/CacheMiddleware/LaravelFileCacheMiddleware.php
+++ b/src/CacheMiddleware/LaravelFileCacheMiddleware.php
@@ -7,7 +7,7 @@ namespace Seatplus\EsiClient\CacheMiddleware;
 use Illuminate\Support\Facades\Cache;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Kevinrob\GuzzleCache\Storage\LaravelCacheStorage;
-use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
+use Seatplus\EsiClient\CacheMiddleware\Strategy\EsiPrivateCacheStrategy;
 
 class LaravelFileCacheMiddleware implements CacheMiddlewareInterface
 {
@@ -15,7 +15,7 @@ class LaravelFileCacheMiddleware implements CacheMiddlewareInterface
     public function getCacheMiddleware(): CacheMiddleware
     {
         return new CacheMiddleware(
-            new PrivateCacheStrategy(
+            new EsiPrivateCacheStrategy(
                 new LaravelCacheStorage(
                     Cache::store('file')
                 )

--- a/src/CacheMiddleware/Strategy/EsiPrivateCacheStrategy.php
+++ b/src/CacheMiddleware/Strategy/EsiPrivateCacheStrategy.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seatplus\EsiClient\CacheMiddleware\Strategy;
+
+use Firebase\JWT\JWT;
+use Kevinrob\GuzzleCache\KeyValueHttpHeader;
+use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
+use Psr\Http\Message\RequestInterface;
+use Seatplus\EsiSchema\GeneratedSpec;
+
+/**
+ * RFC 7234 private cache scoped to the caller and to the ESI compatibility date.
+ *
+ * Upstream keys on method + URI only. ESI does not vary on Authorization, so two characters
+ * requesting the same authenticated URI share one entry — a character lacking a corporation
+ * role can be served a payload another character fetched, and ESI never sees the request that
+ * would have been refused. Entries carrying an ETag are stored with an infinite TTL, so that
+ * bleed does not age out. Scoping the key to the token's subject fixes it without the cost of
+ * keying on the raw bearer token, which rotates every ~20 minutes and would miss more often
+ * than ESI's TTLs allow.
+ *
+ * The compatibility date is folded in as well. ESI currently sends
+ * `Vary: X-Compatibility-Date`, which the vendor already honours, so this salt is defence in
+ * depth should CCP stop sending it — not a fix for a live bug.
+ *
+ * The `sub` claim is read without signature verification. That is strictly better than keying
+ * on nothing and strictly weaker than keying on the raw token: it only helps against a caller
+ * who cannot already supply an arbitrary token.
+ */
+class EsiPrivateCacheStrategy extends PrivateCacheStrategy
+{
+    #[\Override]
+    protected function getCacheKey(RequestInterface $request, ?KeyValueHttpHeader $varyHeaders = null): string
+    {
+        $compatibility_date = $request->getHeaderLine(GeneratedSpec::COMPATIBILITY_DATE_HEADER);
+
+        return hash(
+            'sha256',
+            $compatibility_date.'|'.$this->tokenIdentity($request).'|'.parent::getCacheKey($request, $varyHeaders),
+        );
+    }
+
+    /**
+     * Stable identity of the OAuth principal, or '' for an unauthenticated request.
+     *
+     * Falls back to hashing the raw header when the token is not a readable JWT: isolation at
+     * the cost of caching only for that token's lifetime.
+     */
+    private function tokenIdentity(RequestInterface $request): string
+    {
+        $authorization = $request->getHeaderLine('Authorization');
+
+        if ($authorization === '') {
+            return '';
+        }
+
+        $segments = explode('.', $authorization);
+
+        if (count($segments) < 3) {
+            return hash('sha256', $authorization);
+        }
+
+        $payload = json_decode(JWT::urlsafeB64Decode($segments[1]));
+
+        if (is_object($payload) && isset($payload->sub) && is_string($payload->sub)) {
+            return $payload->sub;
+        }
+
+        return hash('sha256', $authorization);
+    }
+}

--- a/src/EsiClient.php
+++ b/src/EsiClient.php
@@ -70,7 +70,7 @@ class EsiClient implements EsiTransportInterface
      * Return a new client instance with the given OAuth access token set.
      * Use this for authenticated ESI endpoints.
      *
-     * @example $esi->withToken($accessToken)->characters()->getCharactersCharacterId($id)
+     * @example $esi->withToken($accessToken)->characters()->getCharactersDetail($id)
      */
     public function withToken(string $accessToken): static
     {

--- a/src/EsiConfiguration.php
+++ b/src/EsiConfiguration.php
@@ -11,6 +11,7 @@ use Seatplus\EsiClient\CacheMiddleware\NullCacheMiddleware;
 use Seatplus\EsiClient\Fetcher\GuzzleFetcher;
 use Seatplus\EsiClient\Log\LogInterface;
 use Seatplus\EsiClient\Log\RotatingFileLogger;
+use Seatplus\EsiSchema\GeneratedSpec;
 
 class EsiConfiguration
 {
@@ -49,9 +50,10 @@ class EsiConfiguration
         public string $fetcher = GuzzleFetcher::class,
 
         // Versioning — X-Compatibility-Date header value (YYYY-MM-DD).
-        // Sent on every request. Matches the ESI OpenAPI spec compatibility date
-        // used to generate seatplus/esi-schema. Update when regenerating the schema.
-        public ?string $compatibility_date = '2025-12-16',
+        // Sent on every request. Sourced from seatplus/esi-schema, which is generated
+        // against exactly this spec date, so the DTOs and the wire contract cannot drift
+        // apart. Pass null to omit the header and let ESI apply its own default.
+        public ?string $compatibility_date = GeneratedSpec::COMPATIBILITY_DATE,
     ) {
         if ($this->http_user_agent === '') {
             $version = InstalledVersions::getPrettyVersion('seatplus/esi-client') ?? 'dev';

--- a/src/Fetcher/GuzzleFetcher.php
+++ b/src/Fetcher/GuzzleFetcher.php
@@ -22,6 +22,7 @@ use Seatplus\EsiClient\Exceptions\InvalidAuthenticationException;
 use Seatplus\EsiClient\Exceptions\RequestFailedException;
 use Seatplus\EsiClient\Log\LogInterface;
 use Seatplus\EsiClient\Services\UpdateRefreshTokenService;
+use Seatplus\EsiSchema\GeneratedSpec;
 
 class GuzzleFetcher
 {
@@ -83,8 +84,10 @@ class GuzzleFetcher
             'User-Agent' => EsiConfiguration::getInstance()->http_user_agent,
         ]);
 
-        if (EsiConfiguration::getInstance()->compatibility_date !== null) {
-            $requestHeaders['X-Compatibility-Date'] = EsiConfiguration::getInstance()->compatibility_date;
+        $compatibility_date = EsiConfiguration::getInstance()->compatibility_date;
+
+        if ($compatibility_date !== null) {
+            $requestHeaders[GeneratedSpec::COMPATIBILITY_DATE_HEADER] = $compatibility_date;
         }
 
         try {

--- a/tests/.pest/shards.json
+++ b/tests/.pest/shards.json
@@ -1,19 +1,20 @@
 {
     "timings": {
-        "Tests\\Unit\\CacheMiddleware\\LaravelFileCacheMiddlewareTest": 0.0131,
-        "Tests\\Unit\\DataTransferObject\\EsiResponseTest": 0.0112,
-        "Tests\\Unit\\EsiAuthenticationTest": 0.0056,
-        "Tests\\Unit\\EsiClientTest": 0.0107,
-        "Tests\\Unit\\EsiConfigurationTest": 0.0263,
-        "Tests\\Unit\\Fetcher\\GuzzleFetcherTest": 0.1648,
-        "Tests\\Unit\\GeneratedResourcesTest": 0.0422,
-        "Tests\\Unit\\Logger\\NullLoggerTest": 0.0034,
-        "Tests\\Unit\\Logger\\RotatingFileLoggerTest": 0.0274,
-        "Tests\\Unit\\Services\\JwtServiceTest": 0.0045,
-        "Tests\\Unit\\Services\\RefreshTokenServiceTest": 0.1984,
-        "Tests\\Unit\\Services\\UpdateRefreshToklenServiceTest": 0.0083,
-        "Tests\\Unit\\Services\\VerifyAccessTokenTest": 0.0066
+        "Tests\\Unit\\CacheMiddleware\\LaravelFileCacheMiddlewareTest": 0.0104,
+        "Tests\\Unit\\CacheMiddleware\\Strategy\\EsiPrivateCacheStrategyTest": 0.0677,
+        "Tests\\Unit\\DataTransferObject\\EsiResponseTest": 0.0216,
+        "Tests\\Unit\\EsiAuthenticationTest": 0.0405,
+        "Tests\\Unit\\EsiClientTest": 0.0201,
+        "Tests\\Unit\\EsiConfigurationTest": 0.0124,
+        "Tests\\Unit\\Fetcher\\GuzzleFetcherTest": 0.0696,
+        "Tests\\Unit\\GeneratedResourcesTest": 0.1453,
+        "Tests\\Unit\\Logger\\NullLoggerTest": 0.0404,
+        "Tests\\Unit\\Logger\\RotatingFileLoggerTest": 0.1385,
+        "Tests\\Unit\\Services\\JwtServiceTest": 0.0295,
+        "Tests\\Unit\\Services\\RefreshTokenServiceTest": 0.4442,
+        "Tests\\Unit\\Services\\UpdateRefreshToklenServiceTest": 0.3653,
+        "Tests\\Unit\\Services\\VerifyAccessTokenTest": 0.0301
     },
-    "checksum": "a6536df9f90f65cc973d8b673f672534",
-    "updated_at": "2026-07-30T15:09:38+00:00"
+    "checksum": "4e048f04f9a1439443f06278bda34d44",
+    "updated_at": "2026-08-04T12:53:31+00:00"
 }

--- a/tests/Unit/CacheMiddleware/LaravelFileCacheMiddlewareTest.php
+++ b/tests/Unit/CacheMiddleware/LaravelFileCacheMiddlewareTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Contracts\Cache\Repository;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Seatplus\EsiClient\CacheMiddleware\LaravelFileCacheMiddleware;
+use Seatplus\EsiClient\CacheMiddleware\Strategy\EsiPrivateCacheStrategy;
 
 it('returns a CacheMiddleware instance', function () {
     // Mock the Cache facade
@@ -16,7 +17,10 @@ it('returns a CacheMiddleware instance', function () {
     $middleware = new LaravelFileCacheMiddleware;
     $result = $middleware->getCacheMiddleware();
 
-    expect($result)->toBeInstanceOf(CacheMiddleware::class);
+    // getCacheStorage() returns the strategy, despite the name. Asserting it pins the wiring:
+    // without this the test would pass just as happily on the unscoped PrivateCacheStrategy.
+    expect($result)->toBeInstanceOf(CacheMiddleware::class)
+        ->and($result->getCacheStorage())->toBeInstanceOf(EsiPrivateCacheStrategy::class);
 
     Mockery::close();
 });

--- a/tests/Unit/CacheMiddleware/Strategy/EsiPrivateCacheStrategyTest.php
+++ b/tests/Unit/CacheMiddleware/Strategy/EsiPrivateCacheStrategyTest.php
@@ -1,0 +1,168 @@
+<?php
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Kevinrob\GuzzleCache\CacheEntry;
+use Kevinrob\GuzzleCache\CacheMiddleware;
+use Kevinrob\GuzzleCache\Storage\VolatileRuntimeStorage;
+use Seatplus\EsiClient\CacheMiddleware\Strategy\EsiPrivateCacheStrategy;
+use Seatplus\EsiClient\EsiConfiguration;
+use Seatplus\EsiClient\Fetcher\GuzzleFetcher;
+use Seatplus\EsiClient\Log\NullLogger;
+use Seatplus\EsiSchema\GeneratedSpec;
+
+function esiCacheRequest(?string $compatibility_date = null, ?string $token = null): Request
+{
+    $headers = [];
+
+    if ($compatibility_date !== null) {
+        $headers[GeneratedSpec::COMPATIBILITY_DATE_HEADER] = $compatibility_date;
+    }
+
+    if ($token !== null) {
+        $headers['Authorization'] = "Bearer {$token}";
+    }
+
+    return new Request('GET', 'https://esi.evetech.net/characters/95725047/', $headers);
+}
+
+/**
+ * Cacheable purely by max-age — deliberately no ETag/Last-Modified, which would make the entry
+ * revalidatable and require the transport to serve a 304.
+ */
+function esiCacheableResponse(string $body, array $headers = []): Response
+{
+    return new Response(200, array_merge(['Cache-Control' => 'max-age=3600'], $headers), $body);
+}
+
+function esiJwt(array $claims): string
+{
+    return buildJWT(json_encode($claims));
+}
+
+it('serves a hit for an identical request', function () {
+    $strategy = new EsiPrivateCacheStrategy(new VolatileRuntimeStorage);
+
+    expect($strategy->cache(esiCacheRequest('2026-07-21'), esiCacheableResponse('{"name":"A"}')))->toBeTrue();
+
+    $hit = $strategy->fetch(esiCacheRequest('2026-07-21'));
+
+    expect($hit)->toBeInstanceOf(CacheEntry::class)
+        ->and($hit?->getResponse()->getBody()->getContents())->toBe('{"name":"A"}');
+});
+
+it('misses when the compatibility date changed', function () {
+    $strategy = new EsiPrivateCacheStrategy(new VolatileRuntimeStorage);
+
+    $strategy->cache(esiCacheRequest('2026-07-21'), esiCacheableResponse('{"name":"A"}'));
+
+    expect($strategy->fetch(esiCacheRequest('2025-12-16')))->toBeNull();
+});
+
+it('keeps requests without a compatibility date in their own keyspace', function () {
+    $strategy = new EsiPrivateCacheStrategy(new VolatileRuntimeStorage);
+
+    $strategy->cache(esiCacheRequest(), esiCacheableResponse('{"name":"undated"}'));
+
+    expect($strategy->fetch(esiCacheRequest()))->toBeInstanceOf(CacheEntry::class)
+        ->and($strategy->fetch(esiCacheRequest('2026-07-21')))->toBeNull();
+
+    $dated = new EsiPrivateCacheStrategy(new VolatileRuntimeStorage);
+    $dated->cache(esiCacheRequest('2026-07-21'), esiCacheableResponse('{"name":"dated"}'));
+
+    expect($dated->fetch(esiCacheRequest()))->toBeNull();
+});
+
+it('misses when the token belongs to a different character', function () {
+    $strategy = new EsiPrivateCacheStrategy(new VolatileRuntimeStorage);
+
+    $accountant = esiJwt(['sub' => 'CHARACTER:EVE:95725047']);
+    $other = esiJwt(['sub' => 'CHARACTER:EVE:90000001']);
+
+    $strategy->cache(
+        esiCacheRequest('2026-07-21', $accountant),
+        esiCacheableResponse('{"balance":42}'),
+    );
+
+    expect($strategy->fetch(esiCacheRequest('2026-07-21', $accountant)))->toBeInstanceOf(CacheEntry::class)
+        ->and($strategy->fetch(esiCacheRequest('2026-07-21', $other)))->toBeNull();
+});
+
+it('does not serve an authenticated payload to an anonymous request', function () {
+    $strategy = new EsiPrivateCacheStrategy(new VolatileRuntimeStorage);
+
+    $strategy->cache(
+        esiCacheRequest('2026-07-21', esiJwt(['sub' => 'CHARACTER:EVE:95725047'])),
+        esiCacheableResponse('{"balance":42}'),
+    );
+
+    expect($strategy->fetch(esiCacheRequest('2026-07-21')))->toBeNull();
+});
+
+it('isolates tokens it cannot read as a JWT subject', function (array|string $first, array|string $second) {
+    $strategy = new EsiPrivateCacheStrategy(new VolatileRuntimeStorage);
+
+    $one = is_array($first) ? esiJwt($first) : $first;
+    $two = is_array($second) ? esiJwt($second) : $second;
+
+    $strategy->cache(esiCacheRequest('2026-07-21', $one), esiCacheableResponse('{"name":"A"}'));
+
+    expect($strategy->fetch(esiCacheRequest('2026-07-21', $one)))->toBeInstanceOf(CacheEntry::class)
+        ->and($strategy->fetch(esiCacheRequest('2026-07-21', $two)))->toBeNull();
+})->with([
+    // Opaque, non-JWT tokens: fewer than three dot-separated segments.
+    'opaque token' => ['opaque-token-one', 'opaque-token-two'],
+    // Readable JWTs that carry no `sub` claim.
+    'jwt without sub' => [['scp' => ['esi-assets.read_assets.v1']], ['scp' => ['esi-wallet.read_corporation_wallets.v1']]],
+]);
+
+it('still honours a Vary header sent by the server', function () {
+    $strategy = new EsiPrivateCacheStrategy(new VolatileRuntimeStorage);
+
+    $strategy->cache(
+        esiCacheRequest('2026-07-21'),
+        esiCacheableResponse('{"name":"A"}', ['Vary' => 'Accept-Language']),
+    );
+
+    expect($strategy->fetch(esiCacheRequest('2026-07-21')))->toBeInstanceOf(CacheEntry::class)
+        ->and($strategy->fetch(esiCacheRequest('2025-12-16')))->toBeNull();
+});
+
+it('serves a cold cache after the compatibility date changes', function () {
+    // Two responses for three calls: the second call is a HIT and never reaches the transport.
+    $mock = new MockHandler([
+        esiCacheableResponse(json_encode(['name' => 'old-date'])),
+        esiCacheableResponse(json_encode(['name' => 'new-date'])),
+    ]);
+
+    $stack = HandlerStack::create($mock);
+    $stack->push(new CacheMiddleware(new EsiPrivateCacheStrategy(new VolatileRuntimeStorage)), 'cache');
+
+    EsiConfiguration::resetInstance();
+    EsiConfiguration::getInstance(compatibility_date: '2026-07-21');
+
+    $fetcher = new GuzzleFetcher(logger: new NullLogger, client: new Client(['handler' => $stack]));
+
+    $first = $fetcher->call('get', 'https://esi.evetech.net/characters/95725047/');
+    $second = $fetcher->call('get', 'https://esi.evetech.net/characters/95725047/');
+
+    expect($first->isCachedLoad())->toBeFalse()
+        ->and($second->isCachedLoad())->toBeTrue()
+        ->and($second->data->name)->toBe('old-date');
+
+    // Production shape: EsiConfiguration memoises getCacheMiddleware() per instance while
+    // compatibility_date stays publicly mutable, so a strategy that captured the date at
+    // construction would reuse the stale key. The tests above also catch that; this one
+    // additionally proves GuzzleFetcher puts the header where the strategy reads it.
+    EsiConfiguration::getInstance()->compatibility_date = '2025-12-16';
+
+    $third = $fetcher->call('get', 'https://esi.evetech.net/characters/95725047/');
+
+    expect($third->isCachedLoad())->toBeFalse()
+        ->and($third->data->name)->toBe('new-date');
+
+    EsiConfiguration::resetInstance();
+});

--- a/tests/Unit/EsiConfigurationTest.php
+++ b/tests/Unit/EsiConfigurationTest.php
@@ -6,6 +6,7 @@ use Seatplus\EsiClient\EsiConfiguration;
 use Seatplus\EsiClient\Fetcher\GuzzleFetcher;
 use Seatplus\EsiClient\Log\LogInterface;
 use Seatplus\EsiClient\Log\NullLogger;
+use Seatplus\EsiSchema\GeneratedSpec;
 
 it('initializes with default values', function () {
     $config = new EsiConfiguration;
@@ -23,7 +24,7 @@ it('initializes with default values', function () {
         ->and($config->log_max_files)->toBe(10)
         ->and($config->cache_middleware)->toBe(NullCacheMiddleware::class)
         ->and($config->fetcher)->toBe(GuzzleFetcher::class)
-        ->and($config->compatibility_date)->toBe('2025-12-16');
+        ->and($config->compatibility_date)->toBe(GeneratedSpec::COMPATIBILITY_DATE);
 });
 
 it('singleton instance is consistent', function () {
@@ -63,11 +64,11 @@ it('compatibility_date can be set via constructor', function () {
     expect($config->compatibility_date)->toBe('2025-10-01');
 });
 
-it('compatibility_date defaults to 2025-12-16', function () {
+it('compatibility_date defaults to the date esi-schema was generated for', function () {
     EsiConfiguration::resetInstance();
     $config = EsiConfiguration::getInstance();
 
-    expect($config->compatibility_date)->toBe('2025-12-16');
+    expect($config->compatibility_date)->toBe(GeneratedSpec::COMPATIBILITY_DATE);
 
     EsiConfiguration::resetInstance();
 });

--- a/tests/Unit/Fetcher/GuzzleFetcherTest.php
+++ b/tests/Unit/Fetcher/GuzzleFetcherTest.php
@@ -210,6 +210,8 @@ it('does not send X-Compatibility-Date header when compatibility_date is null', 
     $fetcher->call('get', '/foo');
 
     expect($sentHeaders)->not->toHaveKey('X-Compatibility-Date');
+
+    EsiConfiguration::resetInstance();
 });
 
 it('logs fetcher activity with cache hit', function (string $log_level) {

--- a/tests/Unit/GeneratedResourcesTest.php
+++ b/tests/Unit/GeneratedResourcesTest.php
@@ -82,7 +82,7 @@ it('universe() returns a UniverseResource', function () {
 // Object response — returns DTO directly (no EsiResult wrapper)
 // ---------------------------------------------------------------------------
 
-it('getCharactersCharacterId returns CharactersDetail DTO directly', function () {
+it('getCharactersDetail returns CharactersDetail DTO directly', function () {
     $raw = json_encode([
         'name' => 'Test Pilot',
         'corporation_id' => 98000001,
@@ -97,7 +97,7 @@ it('getCharactersCharacterId returns CharactersDetail DTO directly', function ()
     $fetcher->shouldReceive('call')->once()->andReturn(makeEsiResponse($raw));
 
     $client = new EsiClient(new EsiAuthentication('tok', ''), $fetcher);
-    $dto = $client->characters()->getCharactersCharacterId(123);
+    $dto = $client->characters()->getCharactersDetail(123);
 
     expect($dto)->toBeInstanceOf(CharactersDetail::class)
         ->and($dto->name)->toBe('Test Pilot')


### PR DESCRIPTION
Resolves #44. Unblocks seatplus/eveapi#714.

## What

Adopts `seatplus/esi-schema` 3.0:

- `require.php` → `^8.5` (esi-schema 3.0 requires it)
- `seatplus/esi-schema` → `^3.0`
- `CharacterResource::getCharactersCharacterId()` → `getCharactersDetail()`, the rename CCP made at compatibility date `2026-06-09`. Four call sites, one of which (`README.md:44`) the issue does not list.
- `X-Compatibility-Date` is now read from `GeneratedSpec::COMPATIBILITY_DATE` instead of a literal, so the generated DTOs and the wire contract cannot drift apart.

## Two of the issue's premises did not survive verification

**The compatibility-date cache-replay bug does not exist.** ESI already varies on the header:

```
$ curl -sD - -o /dev/null -H 'X-Compatibility-Date: 2026-07-21' https://esi.evetech.net/characters/95725047/
vary: X-Tenant
vary: Accept-Language
vary: X-Compatibility-Date
x-compatibility-date: 2026-06-09
```

`kevinrob/guzzle-cache-middleware` 7.0.0 honours a server `Vary` — `cache()` stores under a vary-derived key as well as the URI-only key, and `fetch()` runs `CacheEntry::isVaryEquals()`, which rejects a date mismatch. Reproduced against the real vendor middleware: with the header present, a date change correctly misses.

**But `Authorization` is absent from that `Vary` list**, including on authenticated routes (checked against `/characters/{id}/assets/` and `/corporations/{id}/wallets/1/journal/`), and the upstream key was method + URI only. So two characters requesting the same authenticated URI shared one entry: a corp Accountant fetches `/corporations/{id}/wallets/1/journal/`, then a character *without* that role is served the cached body and ESI never sees the request that would have been refused. Because ESI sends `ETag`, `CacheEntry::getTTL()` returns `0` and `LaravelCacheStorage::save()` uses `Cache::forever()` — so it did not age out.

So the cache work stays, re-aimed at the axis that was actually broken. `EsiPrivateCacheStrategy` keys on `sha256(compatibility-date | JWT sub | method + URI)`. The `sub` claim is stable across token refresh, unlike the raw bearer token, which rotates every ~20 minutes and would miss more often than ESI's TTLs allow. Both salts are read off the request, not from the config singleton — `EsiConfiguration` memoises the middleware per instance while `compatibility_date` stays publicly mutable, so a captured date would go stale.

**Blast radius today is nil**: the shipped default is `NullCacheMiddleware` and nothing in the org sets `cache_middleware`. This is a correctness fix for opt-in and third-party users.

## Scope of the 1.3.1 → 3.0.0 jump

Diffed the tags directly, since esi-schema 3.0.0's release note says *"Baseline 2.0.0 has no surface manifest; treating as major"* — no classified diff exists.

- Complete breaking set is **3 classes and 3 wrapper methods**: the `GetCharactersDetail` rename, plus `GetSovereigntyMap` / `GetSovereigntyStructures` and their two DTOs removed. This package references none of the removals.
- **All 238 surviving wrapper method signatures unchanged.**
- `EsiTransportInterface`, `EsiRawResponse`, `EsiCursor`, `EsiResult`, `AbstractEsiDto`, `OperationMeta`, `EsiOperationInterface`, `ScopeAccessDeniedException` are **byte-identical** — so `EsiClient`'s `implements EsiTransportInterface` and its nine-named-argument `new EsiRawResponse(...)` are safe.
- Field-level DTO changes are confined to `CharactersDetail`, `CorporationsDetail` and `Error`. None of the changed fields are referenced here.
- `CharactersDetail::from()` is defensive (`(int) ($data->achievement_score ?? 0)`), so the existing test fixture still hydrates.

## Incidental fixes

Found while in these files:

- `guzzlehttp/guzzle` declared in `require` — used directly by `GuzzleFetcher`, previously only transitive via the cache middleware.
- `rector.php` listed a non-existent `bin/` path, so `rector process` errored out entirely and `SetList::PHP_85` was protecting nothing.
- `formats.yml`'s `push:` trigger had **no branch filter**, so it ran on every branch and published a check named `ci` — the same context branch protection requires. A PR whose base wasn't covered by `tests.yml` therefore showed one green tick that looked like a validated build. Now branch-filtered, and `5.x` added to both workflows.
- Fixed a singleton leak in `GuzzleFetcherTest` (set `compatibility_date: null` and never reset, under `executionOrder="random"`).
- `illuminate/cache` widened to `^11.23 || ^12.0 || ^13.0` to cover the Laravel line consumers run. Honest caveat: CI resolves the highest member, so the effective dev target becomes Laravel 13 and 11/12 are declared-but-untested absent a `--prefer-lowest` job.

## Testing

`composer run test` exits 0: Pint, PHPStan level 4 over `src` **and** `tests`, type coverage **100%** (including the new strategy), 114 tests passing — stable across repeated random seeds.

9 new tests in `EsiPrivateCacheStrategyTest` cover cross-character isolation, all three `tokenIdentity()` fallbacks (no header, opaque non-JWT, JWT without `sub`), date keyspace separation, `Vary` forwarding, and an end-to-end cold cache through `MockHandler` + `GuzzleFetcher`. `LaravelFileCacheMiddlewareTest` now asserts the strategy type, so reverting the wiring fails.

## Before tagging

**esi-schema 3.0.0 has a regression this package re-exports.** `Resources\Skills\GetCharactersCharacterIdSkillqueue::execute()` went from `data: array_map(fn ($item) => CharactersSkillqueueSkill::from($item), …)` in 1.3.1 to `data: null` in 3.0.0 — the only GET among 28 operations doing that, leaving `Responses\CharactersSkillqueueSkill` orphaned. `skills()->getCharactersCharacterIdSkillqueue()` will silently return nothing, and there is no test coverage here, so CI stays green. Worth fixing upstream before 5.0.0 is tagged.

**Latent vendor break:** kevinrob 7.0.0's `CacheEntry::getResponse()` passes an `int` to `withHeader('Age', …)` — deprecated since guzzlehttp/psr7 2.11, rejected in 3.0. Every cache HIT triggers it; the new end-to-end test is the first here to produce one. Bounded today by kevinrob's `psr7: ^2.7.0` pin.

## Note on the base branch

This PR currently targets `4.x`. Per the plan it should ship as **5.0.0 on a new `5.x` branch**, leaving `4.x` as the PHP 8.3/8.4 maintenance line — a PHP-floor break plus a compatibility-date change is not a `4.x` minor. `5.x` does not exist on the remote yet. If it is cut and this is retargeted, keep `5.x` unprotected until this merges, since the CI branch-filter commit lives inside this PR.
