### PR TITLE
Use esi schema 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "kevinrob/guzzle-cache-middleware": "^7.0",
         "monolog/monolog": "^3.7",
         "nesbot/carbon": "^3.0",
-        "seatplus/esi-schema": "^3.0"
+        "seatplus/esi-schema": "^4.0"
     },
     "require-dev": {
         "ext-openssl": "*",

--- a/tests/Unit/GeneratedResourcesTest.php
+++ b/tests/Unit/GeneratedResourcesTest.php
@@ -4,12 +4,14 @@ use Seatplus\EsiClient\DataTransferObjects\EsiAuthentication;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\EsiClient\EsiClient;
 use Seatplus\EsiClient\Fetcher\GuzzleFetcher;
+use Seatplus\EsiSchema\Contracts\ScopeAccessDeniedException;
 use Seatplus\EsiSchema\EsiResult;
 use Seatplus\EsiSchema\Resources\AllianceResource;
 use Seatplus\EsiSchema\Resources\CharacterResource;
 use Seatplus\EsiSchema\Resources\UniverseResource;
 use Seatplus\EsiSchema\Responses\AllianceDetail;
 use Seatplus\EsiSchema\Responses\CharactersDetail;
+use Seatplus\EsiSchema\Responses\CharactersSkillqueueSkill;
 use Seatplus\EsiSchema\Responses\UniverseTypesTypeIdGet;
 
 function makeEsiResponse(string $raw, array $headers = []): EsiResponse
@@ -127,6 +129,72 @@ it('paginated resource returns correct page count from X-Pages header', function
         ->and($result->pages)->toBe(4)
         ->and($result->data)->toBeArray()
         ->and($result->data)->toHaveCount(1);
+});
+
+// ---------------------------------------------------------------------------
+// Non-paginated array response — hydrated into DTOs, not dropped
+//
+// Regression guard: esi-schema 3.0.0 shipped this operation with `data: null`,
+// so the skill queue came back silently empty. Fixed in 4.0.0.
+// ---------------------------------------------------------------------------
+
+it('getCharactersCharacterIdSkillqueue hydrates the queue into DTOs', function () {
+    $raw = json_encode([
+        [
+            'finished_level' => 4,
+            'queue_position' => 0,
+            'skill_id' => 3300,
+            'finish_date' => '2026-08-10T12:00:00Z',
+            'start_date' => '2026-08-04T12:00:00Z',
+            'level_end_sp' => 45255,
+            'level_start_sp' => 8000,
+            'training_start_sp' => 8000,
+        ],
+        [
+            'finished_level' => 5,
+            'queue_position' => 1,
+            'skill_id' => 3301,
+        ],
+    ]);
+
+    $fetcher = mock(GuzzleFetcher::class);
+    $fetcher->shouldReceive('call')->once()->andReturn(makeEsiResponse($raw));
+
+    $client = makeAuthedClient($fetcher, ['esi-skills.read_skillqueue.v1']);
+    $result = $client->skills()->getCharactersCharacterIdSkillqueue(123);
+
+    expect($result)->toBeInstanceOf(EsiResult::class)
+        ->and($result->data)->toBeArray()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0])->toBeInstanceOf(CharactersSkillqueueSkill::class)
+        ->and($result->data[0]->skill_id)->toBe(3300)
+        ->and($result->data[0]->queue_position)->toBe(0)
+        ->and($result->data[0]->finished_level)->toBe(4)
+        ->and($result->data[0]->finish_date)->toBe('2026-08-10T12:00:00Z')
+        ->and($result->data[1])->toBeInstanceOf(CharactersSkillqueueSkill::class)
+        ->and($result->data[1]->skill_id)->toBe(3301)
+        ->and($result->data[1]->finish_date)->toBeNull();
+});
+
+it('getCharactersCharacterIdSkillqueue returns an empty array for an empty queue', function () {
+    $fetcher = mock(GuzzleFetcher::class);
+    $fetcher->shouldReceive('call')->once()->andReturn(makeEsiResponse('[]'));
+
+    $client = makeAuthedClient($fetcher, ['esi-skills.read_skillqueue.v1']);
+    $result = $client->skills()->getCharactersCharacterIdSkillqueue(123);
+
+    expect($result->data)->toBeArray()
+        ->and($result->data)->toBeEmpty();
+});
+
+it('getCharactersCharacterIdSkillqueue requires the read_skillqueue scope', function () {
+    $fetcher = mock(GuzzleFetcher::class);
+    $fetcher->shouldNotReceive('call');
+
+    $client = makeAuthedClient($fetcher, ['esi-assets.read_assets.v1']);
+
+    expect(fn () => $client->skills()->getCharactersCharacterIdSkillqueue(123))
+        ->toThrow(ScopeAccessDeniedException::class);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follows #45. Picks up the skillqueue regression that PR's *"Before tagging"* section flagged — esi-schema 4.0.0 fixes it upstream.

## What

One line of production change: `seatplus/esi-schema` `^3.0` → `^4.0`. No `src/` change is needed in this package. Plus three tests guarding the behaviour 4.0.0 restores — the gap #45 called out.

## Why now

#45 shipped against esi-schema 3.0.0 and closed with a warning: `Resources\Skills\GetCharactersCharacterIdSkillqueue::execute()` returned `data: null` — the only GET among 28 operations doing so — leaving `Responses\CharactersSkillqueueSkill` orphaned, so `skills()->getCharactersCharacterIdSkillqueue()` silently returned nothing. 4.0.0 fixes exactly that:

```diff
-            data: null,
+            data: array_map(
+                fn (object $item) => CharactersSkillqueueSkill::from($item),
+                (array) $response->data,
+            ),
```

Upstream also added `bin/lib/response-shape.php` plus `ResponseShapeTest`, so the generator now derives the response shape rather than defaulting to `null` — this class of regression should not recur.

## Scope of the 3.0.0 → 4.0.0 jump

Diffed the tags directly. **22 files changed, no class or method removed.** All 11 breaking entries in the release note are the same shape: a return type *widening* from `EsiResult<null>` (or a bare `EsiResult`) to the payload that was always on the wire.

| Operation | 3.0.0 | 4.0.0 |
| --- | --- | --- |
| `Character\PostCharactersCharacterIdCspa` | `EsiResult<null>` | `EsiResult<float>` |
| `Contacts\PostCharactersCharacterIdContacts` | `EsiResult<null>` | `EsiResult<array<int>>` |
| `Mail\PostCharactersCharacterIdMail` | `EsiResult<null>` | `EsiResult<int>` |
| `Mail\PostCharactersCharacterIdMailLabels` | `EsiResult<null>` | `EsiResult<int>` |
| `Skills\GetCharactersCharacterIdSkillqueue` | `EsiResult<null>` | `EsiResult<array<CharactersSkillqueueSkill>>` |
| `Fittings\PostCharactersCharacterIdFittings` (+ `FittingsResource` wrapper) | `EsiResult` | `CharactersCharacterIdFittingsPost` |
| `Fleets\PostFleetsFleetIdWings` (+ `FleetsResource` wrapper) | `EsiResult` | `FleetsFleetIdWingsPost` |
| `Fleets\PostFleetsFleetIdWingsWingIdSquads` (+ `FleetsResource` wrapper) | `EsiResult` | `FleetsFleetIdWingsWingIdSquadsPost` |

Things that did **not** move, and which this package depends on:

- **Compatibility date is unchanged at `2026-07-21`** (`.esi/state.json`; `spec_sha256` identical, only `surface_sha256` changed). No wire-contract shift, so `X-Compatibility-Date` sourced from `GeneratedSpec::COMPATIBILITY_DATE` keeps sending the same value and no cache keyspace is invalidated.
- **PHP floor unchanged at `^8.5`.** The only other `composer.json` movement upstream is dev-only (Pest 3 → 5).
- `EsiTransportInterface`, `EsiRawResponse`, `EsiResult`, `EsiCursor`, `AbstractEsiDto`, `OperationMeta`, `EsiOperationInterface`, `GeneratedSpec` — **byte-identical between the tags**. `EsiClient implements EsiTransportInterface` and its nine-named-argument `new EsiRawResponse(...)` are unaffected.
- No DTO field changes.

## Breaking for downstream, not for this package

`EsiClient` calls none of the 11 changed methods — it only hands out resource objects. But three of the changed signatures are on resource wrappers reachable through `EsiClient::fittings()` and `EsiClient::fleets()`, so a consumer assigning the result of `->postCharactersCharacterIdFittings()` to an `EsiResult` breaks at the type level. The re-exported surface changes, therefore this is a **breaking release** and should ship as **5.0.0**, matching where #45 already put the base branch. `5.x` has no tag yet (latest is `4.1.4`), so this can land inside the same major.

## Testing

`composer run test` exits 0 on `^4.0`: Pint, PHPStan level 4 over `src` and `tests`, type coverage **100%**, **117 tests / 230 assertions** passing.

Three new tests in `GeneratedResourcesTest` close the coverage gap that let the 3.0.0 regression through unnoticed:

- **hydration** — a two-entry queue comes back as `CharactersSkillqueueSkill` DTOs with `skill_id` / `queue_position` / `finished_level` / `finish_date` populated, and the nullable fields left `null` on the entry that omits them.
- **empty queue** — a `[]` body yields an empty array, not `null` and not a fatal.
- **scope** — without `esi-skills.read_skillqueue.v1` the call throws `ScopeAccessDeniedException` and never reaches the fetcher.

The first two were verified to **fail** against the old behaviour by reverting the vendored `execute()` back to `data: null` — so they genuinely pin the fix rather than merely passing alongside it. (The scope test passes on both versions; it is coverage, not a regression guard.)

The 12 reported deprecations are pre-existing and unrelated to esi-schema — guzzle 7.11's non-uppercase HTTP method notice from `GuzzleFetcher`, and kevinrob's `withHeader('Age', int)` on every cache HIT, already documented in #45.
