### PR TITLE
Bump seatplus/esi-schema constraint to ^4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "kevinrob/guzzle-cache-middleware": "^8.0",
         "monolog/monolog": "^3.7",
         "nesbot/carbon": "^3.0",
-        "seatplus/esi-schema": "^4.0"
+        "seatplus/esi-schema": "^4.1"
     },
     "require-dev": {
         "ext-openssl": "*",


### PR DESCRIPTION
## Summary
- Relaxes the `seatplus/esi-schema` composer constraint from `^4.0` to `^4.1` to allow picking up the latest 4.x release.

## Testing
- TODO: run `composer run test` to confirm compatibility with esi-schema ^4.1.