### PR TITLE
Contain GuzzleHttp exceptions behind EsiClientException hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,26 @@ receives bug fixes only.
   cached by `4.x` are unreachable from 5.0.0, so expect one cold-fetch cycle per endpoint after
   upgrading and budget for it against ESI's 1800-request / 15-minute window. Old entries are not
   deleted; `php artisan cache:clear` reclaims the space.
+- **No `GuzzleHttp\Exception\*` type escapes this package any more.** Transport failures that never
+  produced a response — DNS failure, refused connection, TLS error, timeout, redirect loop — used to
+  propagate as raw Guzzle types from `GuzzleFetcher::httpRequest()` and
+  `UpdateRefreshTokenService::getRefreshTokenResponse()`, and (undocumented) from
+  `VerifyAccessToken::verify()`. All three now throw
+  `Seatplus\EsiClient\Exceptions\EsiTransportException` with the original exception kept as
+  `getPrevious()`, and the `@throws GuzzleException` docblocks are gone. Response-bearing failures are
+  unaffected: `429` still throws `EsiRateLimitedException`, `420` `EsiErrorLimitedException`, and
+  everything else `RequestFailedException`. Any consumer that catches `GuzzleException` around an
+  esi-client call must catch `EsiTransportException` instead — no such runtime catch site exists in
+  `eveapi`, `auth`, `web`, or `core`, so in practice this only removes the stale `@throws` line in
+  eveapi.
+
+### Added
+
+- **`Seatplus\EsiClient\Exceptions\EsiClientException`**, a marker interface implemented by every
+  exception this package throws, so consumers can `catch (EsiClientException $e)` for "any esi-client
+  failure" instead of enumerating six concrete types. Purely additive — the existing parent classes
+  (`\Exception` / `\RuntimeException`) are unchanged, so current catch sites keep working.
+  `ScopeAccessDeniedException` is deliberately excluded: it belongs to `esi-schema`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,38 @@ queued job.
 If the HTTP client receives a `420 Error Limited` response, the request is retried with
 exponential backoff as configured on the job.
 
+## Error handling
+
+Guzzle is an implementation detail: no `GuzzleHttp\Exception\*` type escapes this package.
+Everything it throws lives in `Seatplus\EsiClient\Exceptions` and implements the
+`EsiClientException` marker interface, so `catch (EsiClientException $e)` catches any
+failure originating here.
+
+| Exception | Meaning |
+| --- | --- |
+| `EsiRateLimitedException` | `429` — token bucket exhausted; `$e->retryAfter` seconds |
+| `EsiErrorLimitedException` | `420` — error limit hit; `$e->retryAfter` seconds |
+| `RequestFailedException` | Any other error response; `$e->getEsiResponse()` has body and headers |
+| `EsiTransportException` | No response at all — DNS, refused connection, TLS, timeout, redirect loop. The underlying client exception is kept as `getPrevious()` |
+| `ExpiredRefreshTokenException` | The supplied `access_token` is expired or expires within the minute — refresh it via `UpdateRefreshTokenService` |
+| `UriDataMissingException` | A path placeholder had no matching value |
+
+One exception is deliberately **not** covered: `assertScope()` throws
+`Seatplus\EsiSchema\Contracts\ScopeAccessDeniedException`, which belongs to `esi-schema`.
+Catch it separately if you need it.
+
+```php
+try {
+    $sdk->withToken($accessToken)->characters()->getCharactersDetail(95725047);
+} catch (EsiRateLimitedException $e) {
+    // back off for $e->retryAfter seconds
+} catch (EsiTransportException $e) {
+    // the ESI was unreachable — retry later
+} catch (EsiClientException $e) {
+    // anything else this package throws
+}
+```
+
 ## Testing
 
 ```bash

--- a/src/EsiClient.php
+++ b/src/EsiClient.php
@@ -7,6 +7,7 @@ namespace Seatplus\EsiClient;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;
 use Seatplus\EsiClient\DataTransferObjects\EsiAuthentication;
+use Seatplus\EsiClient\Exceptions\EsiTransportException;
 use Seatplus\EsiClient\Exceptions\InvalidAuthenticationException;
 use Seatplus\EsiClient\Exceptions\RequestFailedException;
 use Seatplus\EsiClient\Exceptions\UriDataMissingException;
@@ -268,6 +269,7 @@ class EsiClient implements EsiTransportInterface
      * @throws UriDataMissingException
      * @throws InvalidAuthenticationException
      * @throws ScopeAccessDeniedException
+     * @throws EsiTransportException
      */
     public function invoke(
         string $method,

--- a/src/Exceptions/EsiClientException.php
+++ b/src/Exceptions/EsiClientException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seatplus\EsiClient\Exceptions;
+
+/**
+ * Marker interface implemented by every exception esi-client throws.
+ *
+ * Consumers that only care that "the ESI call failed" can catch this instead of
+ * enumerating the concrete types — and without reaching for the HTTP client's
+ * exception hierarchy, which is an implementation detail of this package.
+ */
+interface EsiClientException extends \Throwable {}

--- a/src/Exceptions/EsiErrorLimitedException.php
+++ b/src/Exceptions/EsiErrorLimitedException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Seatplus\EsiClient\Exceptions;
 
-class EsiErrorLimitedException extends \RuntimeException
+class EsiErrorLimitedException extends \RuntimeException implements EsiClientException
 {
     public function __construct(public readonly int $retryAfter = 60)
     {

--- a/src/Exceptions/EsiRateLimitedException.php
+++ b/src/Exceptions/EsiRateLimitedException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Seatplus\EsiClient\Exceptions;
 
-class EsiRateLimitedException extends \RuntimeException
+class EsiRateLimitedException extends \RuntimeException implements EsiClientException
 {
     public function __construct(public readonly int $retryAfter = 60)
     {

--- a/src/Exceptions/EsiTransportException.php
+++ b/src/Exceptions/EsiTransportException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seatplus\EsiClient\Exceptions;
+
+/**
+ * The request never produced an HTTP response: DNS failure, refused connection,
+ * TLS error, timeout, too many redirects.
+ *
+ * A response that arrived but carried an error status surfaces as
+ * RequestFailedException (or the rate/error-limit exceptions) instead.
+ */
+class EsiTransportException extends \RuntimeException implements EsiClientException
+{
+    public function __construct(string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/Exceptions/ExpiredRefreshTokenException.php
+++ b/src/Exceptions/ExpiredRefreshTokenException.php
@@ -6,7 +6,7 @@ namespace Seatplus\EsiClient\Exceptions;
 
 use Seatplus\EsiClient\Services\UpdateRefreshTokenService;
 
-class ExpiredRefreshTokenException extends \Exception
+class ExpiredRefreshTokenException extends \Exception implements EsiClientException
 {
     public function __construct()
     {

--- a/src/Exceptions/InvalidAuthenticationException.php
+++ b/src/Exceptions/InvalidAuthenticationException.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 namespace Seatplus\EsiClient\Exceptions;
 
-class InvalidAuthenticationException extends \Exception {}
+class InvalidAuthenticationException extends \Exception implements EsiClientException {}

--- a/src/Exceptions/RequestFailedException.php
+++ b/src/Exceptions/RequestFailedException.php
@@ -6,7 +6,7 @@ namespace Seatplus\EsiClient\Exceptions;
 
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 
-class RequestFailedException extends \Exception
+class RequestFailedException extends \Exception implements EsiClientException
 {
     public function __construct(private readonly \Exception $original_exception, private readonly EsiResponse $esiResponse)
     {

--- a/src/Exceptions/UriDataMissingException.php
+++ b/src/Exceptions/UriDataMissingException.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 namespace Seatplus\EsiClient\Exceptions;
 
-class UriDataMissingException extends \Exception {}
+class UriDataMissingException extends \Exception implements EsiClientException {}

--- a/src/Fetcher/GuzzleFetcher.php
+++ b/src/Fetcher/GuzzleFetcher.php
@@ -17,6 +17,7 @@ use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\EsiClient\EsiConfiguration;
 use Seatplus\EsiClient\Exceptions\EsiErrorLimitedException;
 use Seatplus\EsiClient\Exceptions\EsiRateLimitedException;
+use Seatplus\EsiClient\Exceptions\EsiTransportException;
 use Seatplus\EsiClient\Exceptions\ExpiredRefreshTokenException;
 use Seatplus\EsiClient\Exceptions\InvalidAuthenticationException;
 use Seatplus\EsiClient\Exceptions\RequestFailedException;
@@ -40,6 +41,7 @@ class GuzzleFetcher
      * @throws InvalidAuthenticationException
      * @throws \Throwable
      * @throws RequestFailedException
+     * @throws EsiTransportException
      */
     public function call(string $method, string $uri, array $body = [], array $headers = []): EsiResponse
     {
@@ -66,10 +68,10 @@ class GuzzleFetcher
     }
 
     /**
-     * @throws GuzzleException
      * @throws EsiRateLimitedException
      * @throws EsiErrorLimitedException
      * @throws RequestFailedException
+     * @throws EsiTransportException
      */
     public function httpRequest(string $method, string $uri, array $headers = [], array $body = []): EsiResponse
     {
@@ -128,6 +130,12 @@ class GuzzleFetcher
                     $statusCode
                 )
             );
+        } catch (GuzzleException $e) {
+            // No response ever arrived (DNS, refused connection, TLS, timeout, redirect loop).
+            // Must stay below the response-bearing catch above — those are GuzzleExceptions too.
+            $this->logger->error("Request for {$method} -> {$uri} -> never reached the ESI: {$e->getMessage()}");
+
+            throw new EsiTransportException("Request to {$uri} failed: {$e->getMessage()}", previous: $e);
         }
 
         $this->logFetcherActivity('log', $response, $method, $uri, $start);

--- a/src/Services/UpdateRefreshTokenService.php
+++ b/src/Services/UpdateRefreshTokenService.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\RequestOptions;
 use Seatplus\EsiClient\DataTransferObjects\EsiAuthentication;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\EsiClient\Exceptions\EsiTransportException;
 use Seatplus\EsiClient\Exceptions\RequestFailedException;
 
 class UpdateRefreshTokenService
@@ -24,7 +25,7 @@ class UpdateRefreshTokenService
 
     /**
      * @throws RequestFailedException
-     * @throws GuzzleException
+     * @throws EsiTransportException
      */
     public function getRefreshTokenResponse(EsiAuthentication $authentication): array
     {
@@ -51,6 +52,13 @@ class UpdateRefreshTokenService
                     'now',
                     $exception->getResponse()->getStatusCode()
                 )
+            );
+        } catch (GuzzleException $exception) {
+            // The SSO token endpoint was unreachable. Must stay below the
+            // response-bearing catch above — those are GuzzleExceptions too.
+            throw new EsiTransportException(
+                'Request to '.self::TOKEN_URL." failed: {$exception->getMessage()}",
+                previous: $exception
             );
         }
 

--- a/src/Services/VerifyAccessToken.php
+++ b/src/Services/VerifyAccessToken.php
@@ -6,6 +6,8 @@ namespace Seatplus\EsiClient\Services;
 
 use Firebase\JWT\ExpiredException;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Seatplus\EsiClient\Exceptions\EsiTransportException;
 use UnexpectedValueException;
 
 class VerifyAccessToken
@@ -16,9 +18,22 @@ class VerifyAccessToken
 
     public function __construct(private readonly Client $client = new Client, private readonly JwtService $jwtService = new JwtService) {}
 
+    /**
+     * @throws EsiTransportException
+     * @throws UnexpectedValueException
+     * @throws ExpiredException
+     */
     public function verify(string $access_token): void
     {
-        $response = $this->client->get(self::JWKS_URL);
+        try {
+            $response = $this->client->get(self::JWKS_URL);
+        } catch (GuzzleException $exception) {
+            throw new EsiTransportException(
+                'Request to '.self::JWKS_URL." failed: {$exception->getMessage()}",
+                previous: $exception
+            );
+        }
+
         $decodedJson = json_decode((string) $response->getBody(), true);
         $parsedKeySet = $this->jwtService->parseJWKS($decodedJson);
 

--- a/tests/Unit/Exceptions/ExceptionHierarchyTest.php
+++ b/tests/Unit/Exceptions/ExceptionHierarchyTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Seatplus\EsiClient\Exceptions\EsiClientException;
+
+it('marks every exception in the package as an EsiClientException', function () {
+    $classes = array_map(
+        fn (string $file): string => 'Seatplus\\EsiClient\\Exceptions\\'.basename($file, '.php'),
+        glob(__DIR__.'/../../../src/Exceptions/*.php') ?: []
+    );
+
+    expect($classes)->not->toBeEmpty();
+
+    foreach ($classes as $class) {
+        $reflection = new ReflectionClass($class);
+
+        // The marker interface itself is in the same directory.
+        if ($reflection->isInterface()) {
+            continue;
+        }
+
+        expect($reflection->implementsInterface(EsiClientException::class))
+            ->toBeTrue("{$class} must implement ".EsiClientException::class);
+    }
+});

--- a/tests/Unit/Fetcher/GuzzleFetcherTest.php
+++ b/tests/Unit/Fetcher/GuzzleFetcherTest.php
@@ -2,16 +2,22 @@
 
 use Carbon\Carbon;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Mockery\MockInterface;
 use Psr\Http\Message\ResponseInterface;
 use Seatplus\EsiClient\DataTransferObjects\EsiAuthentication;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\EsiClient\EsiConfiguration;
+use Seatplus\EsiClient\Exceptions\EsiClientException;
 use Seatplus\EsiClient\Exceptions\EsiErrorLimitedException;
 use Seatplus\EsiClient\Exceptions\EsiRateLimitedException;
+use Seatplus\EsiClient\Exceptions\EsiTransportException;
 use Seatplus\EsiClient\Exceptions\ExpiredRefreshTokenException;
 use Seatplus\EsiClient\Exceptions\RequestFailedException;
 use Seatplus\EsiClient\Fetcher\GuzzleFetcher;
@@ -89,6 +95,70 @@ it('trows RequestFailedException', function () {
 
     $fetcher->call('get', '/foo');
 })->throws(RequestFailedException::class);
+
+it('translates transport failures into EsiTransportException', function (GuzzleException $transportFailure) {
+    $mock = new MockHandler([$transportFailure]);
+
+    $client = new Client(['handler' => HandlerStack::create($mock)]);
+    $fetcher = new GuzzleFetcher(client: $client);
+
+    $fetcher->call('get', '/foo');
+})->with([
+    'connect' => fn () => new ConnectException('cURL error 6: Could not resolve host', new Request('GET', '/foo')),
+    'redirects' => fn () => new TooManyRedirectsException('Will not follow more than 5 redirects', new Request('GET', '/foo')),
+])->throws(EsiTransportException::class);
+
+it('keeps the original transport exception as previous and names the uri', function () {
+    $connectException = new ConnectException('cURL error 28: Operation timed out', new Request('GET', '/foo'));
+
+    $mock = new MockHandler([$connectException]);
+
+    $client = new Client(['handler' => HandlerStack::create($mock)]);
+    $fetcher = new GuzzleFetcher(client: $client);
+
+    try {
+        $fetcher->call('get', '/foo');
+    } catch (EsiTransportException $e) {
+        expect($e->getPrevious())->toBe($connectException)
+            ->and($e->getMessage())->toContain('/foo')
+            ->and($e->getMessage())->toContain('Operation timed out')
+            ->and($e)->toBeInstanceOf(EsiClientException::class);
+    }
+});
+
+it('logs the transport failure as an error', function () {
+    $mock = new MockHandler([
+        new ConnectException('cURL error 7: Connection refused', new Request('GET', '/foo')),
+    ]);
+
+    $logger = mock(LogInterface::class, function (MockInterface $logger) {
+        $logger->shouldReceive('debug')->with(Mockery::type('string'));
+        $logger->shouldReceive('error')
+            ->once()
+            ->with(Mockery::on(fn (string $message): bool => str_contains($message, 'Connection refused')));
+    });
+
+    $client = new Client(['handler' => HandlerStack::create($mock)]);
+    $fetcher = new GuzzleFetcher(client: $client, logger: $logger);
+
+    expect(fn () => $fetcher->call('get', '/foo'))->toThrow(EsiTransportException::class);
+});
+
+it('still throws the response-bearing exceptions rather than EsiTransportException', function (int $status, string $expected) {
+    $mock = new MockHandler([
+        new Response($status, [], json_encode(['error' => 'nope'])),
+    ]);
+
+    $client = new Client(['handler' => HandlerStack::create($mock)]);
+    $fetcher = new GuzzleFetcher(client: $client);
+
+    expect(fn () => $fetcher->call('get', '/foo'))->toThrow($expected);
+})->with([
+    [429, EsiRateLimitedException::class],
+    [420, EsiErrorLimitedException::class],
+    [401, RequestFailedException::class],
+    [500, RequestFailedException::class],
+]);
 
 it('throws EsiRateLimitedException on 429 with Retry-After header', function () {
     $mock = new MockHandler([

--- a/tests/Unit/Services/UpdateRefreshToklenServiceTest.php
+++ b/tests/Unit/Services/UpdateRefreshToklenServiceTest.php
@@ -2,10 +2,12 @@
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Seatplus\EsiClient\DataTransferObjects\EsiAuthentication;
+use Seatplus\EsiClient\Exceptions\EsiTransportException;
 use Seatplus\EsiClient\Exceptions\RequestFailedException;
 use Seatplus\EsiClient\Services\UpdateRefreshTokenService;
 use Seatplus\EsiClient\Services\VerifyAccessToken;
@@ -55,6 +57,26 @@ it('throws RequestFailedException on client error', function () {
 
     expect(fn () => $this->service->getRefreshTokenResponse($authentication))
         ->toThrow(RequestFailedException::class);
+});
+
+it('throws EsiTransportException when the token endpoint is unreachable', function () {
+    $authentication = new EsiAuthentication('client_id', 'secret', 'refresh_token');
+
+    $connectException = new ConnectException(
+        'cURL error 7: Connection refused',
+        new Request('POST', UpdateRefreshTokenService::TOKEN_URL)
+    );
+
+    $this->clientMock->shouldReceive('post')
+        ->once()
+        ->andThrow($connectException);
+
+    try {
+        $this->service->getRefreshTokenResponse($authentication);
+    } catch (EsiTransportException $e) {
+        expect($e->getPrevious())->toBe($connectException)
+            ->and($e->getMessage())->toContain(UpdateRefreshTokenService::TOKEN_URL);
+    }
 });
 
 it('throws RequestFailedException on server error', function () {

--- a/tests/Unit/Services/VerifyAccessTokenTest.php
+++ b/tests/Unit/Services/VerifyAccessTokenTest.php
@@ -2,7 +2,10 @@
 
 use Firebase\JWT\ExpiredException;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Seatplus\EsiClient\Exceptions\EsiTransportException;
 use Seatplus\EsiClient\Services\JwtService;
 use Seatplus\EsiClient\Services\VerifyAccessToken;
 
@@ -37,6 +40,25 @@ it('verifies access token successfully', function () {
         ->andReturn($decodedToken);
 
     $this->service->verify($accessToken);
+});
+
+it('throws EsiTransportException when the JWKS endpoint is unreachable', function () {
+    $connectException = new ConnectException(
+        'cURL error 6: Could not resolve host: login.eveonline.com',
+        new Request('GET', VerifyAccessToken::JWKS_URL)
+    );
+
+    $this->clientMock->shouldReceive('get')
+        ->once()
+        ->with(VerifyAccessToken::JWKS_URL)
+        ->andThrow($connectException);
+
+    try {
+        $this->service->verify('any_access_token');
+    } catch (EsiTransportException $e) {
+        expect($e->getPrevious())->toBe($connectException)
+            ->and($e->getMessage())->toContain(VerifyAccessToken::JWKS_URL);
+    }
 });
 
 it('throws UnexpectedValueException on access token issuer mismatch', function () {


### PR DESCRIPTION
## Summary
- Introduce `EsiClientException`, a marker interface implemented by every exception this package throws, so consumers can `catch (EsiClientException $e)` for any esi-client failure instead of enumerating concrete types.
- Add `EsiTransportException` to cover transport failures that never produced a response (DNS failure, refused connection, TLS error, timeout, redirect loop) in `GuzzleFetcher::httpRequest()`, `UpdateRefreshTokenService::getRefreshTokenResponse()`, and `VerifyAccessToken::verify()`.
- No `GuzzleHttp\Exception\*` type escapes this package anymore — `@throws GuzzleException` docblocks are removed and replaced with `@throws EsiTransportException`. Response-bearing failures are unaffected (`429` → `EsiRateLimitedException`, `420` → `EsiErrorLimitedException`, other error responses → `RequestFailedException`).
- Update README and CHANGELOG to document the new error-handling contract.

Fixes #43

## Testing
- Added `tests/Unit/Exceptions/ExceptionHierarchyTest.php` asserting every concrete exception implements `EsiClientException`.
- Extended `GuzzleFetcherTest`, `UpdateRefreshToklenServiceTest`, and `VerifyAccessTokenTest` with cases for transport failures (connect errors, redirect loops), verifying `EsiTransportException` is thrown with the original exception preserved via `getPrevious()`.